### PR TITLE
feat(http): add support for additional HTTP methods; docs(javadoc): i…

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,106 @@
+# Contributing to Http-Server
+
+Thank you for considering contributing to the Http-Server project! We welcome contributions from everyone and aim to make the process as smooth as possible. This document outlines the steps for setting up the development environment, contributing to the project, and some best practices to follow.
+
+## Table of Contents
+
+- [Getting Started](#getting-started)
+- [Project Structure](#project-structure)
+- [Setting Up the Development Environment](#setting-up-the-development-environment)
+- [Contributing Guidelines](#contributing-guidelines)
+- [Code of Conduct](#code-of-conduct)
+
+
+## Getting Started
+
+To get started with the Http-Server project, please follow these instructions to set up your local development environment.
+
+## Project Structure
+
+The Http-Server project is organized into several key modules:
+
+- `com.httpserver.config`: Contains configuration management classes.
+- `com.httpserver.core`: Contains core server functionalities, including handling HTTP connections.
+- `com.httpserver.utils`: Contains utility classes for JSON processing and other functionalities.
+- `com.httpserver.http`: Handles parsing of HTTP requests, including methods, headers, version management, and the parser itself.
+
+## Setting Up the Development Environment
+
+1. **Prerequisites**:
+    - Java Development Kit (JDK) 11 or later.
+    - Apache Maven for building the project.
+    - An IDE like IntelliJ IDEA or Eclipse (optional but recommended).
+
+2. **Clone the Repository**:
+   ```bash
+   git clone https://github.com/yourusername/Http-Server.git
+   cd Http-Server
+   ```
+   
+3. **Build the Project**: You can build the project using Maven:
+    ```bash
+    mvn clean install
+   ```
+4. **Start the Server**: Run the server using the command:   
+   ```bash
+   java -jar target/httpserver-0.0.1-SNAPSHOT.jar src/main/resources/http.json
+   ```
+
+## Contributing Guidelines
+
+1. **Create a New Branch**: Create a new branch for your feature or fix:
+   ```bash
+   git checkout -b my-feature-branch
+   ```
+
+2. **Make Your Changes**: Implement your changes, ensuring they adhere to the project’s coding standards.
+
+3. **Run Tests**: Ensure that all tests pass by running:
+   ```bash
+   mvn test
+   ```
+
+4. **Commit Your Changes**: Commit your changes with a clear and concise commit message:
+   ```bash
+   git commit -m "Add feature XYZ"
+   ```
+
+5. **Push to Your Fork**: Push your changes to your forked repository:
+   ```bash
+   git push origin my-feature-branch
+   ```
+
+6. **Create a Pull Request**: Go to the original repository and create a pull request, describing your changes and why they are beneficial.
+
+
+## Code of Conduct
+
+### Our Pledge
+
+We pledge to make participation in our project a harassment-free experience for everyone.
+
+### Our Standards
+
+**Positive behavior:**
+- Use inclusive language
+- Respect differing viewpoints
+- Accept constructive criticism
+- Show empathy
+
+**Unacceptable behavior:**
+- Harassment or abuse
+- Insulting comments
+- Personal attacks
+- Publishing private information
+
+### Responsibilities
+
+Maintainers will clarify acceptable behavior and take action against violations. They may remove contributions that don’t align with this Code.
+
+### Scope
+
+This Code applies in project spaces and public spaces when representing the project.
+
+### Acknowledgement
+
+Adapted from the [Contributor Covenant](https://www.contributor-covenant.org).

--- a/src/main/java/com/httpserver/HttpServerApplication.java
+++ b/src/main/java/com/httpserver/HttpServerApplication.java
@@ -8,11 +8,21 @@ import com.httpserver.core.ServerListenerThread;
 import com.httpserver.config.ConfigurationManager;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 
+/**
+ * Main application class for the HTTP server.
+ * This class initializes the server by loading configuration settings
+ * and starting the server listener thread.
+ */
 @SpringBootApplication
 public class HttpServerApplication {
 
 	private final static Logger LOGGER = LoggerFactory.getLogger(HttpServerApplication.class);
 
+	/**
+	 * The entry point of the HTTP server application.
+	 *
+	 * @param args command-line arguments; expects a single argument specifying the configuration file path.
+	 */
 	public static void main(String[] args) {
 
 		if (args.length != 1) {
@@ -23,7 +33,8 @@ public class HttpServerApplication {
 
 		LOGGER.info("Starting server...");
 
-		ConfigurationManager.getInstance().loadConfigurationFile("src/main/resources/http.json");
+		// Load the configuration from the provided JSON file.
+		ConfigurationManager.getInstance().loadConfigurationFile(args[0]);
 		Configuration config = ConfigurationManager.getInstance().getCurrentConfiguration();
 
 		LOGGER.info("Using Port: {}", config.getPort());
@@ -40,5 +51,4 @@ public class HttpServerApplication {
 			e.printStackTrace();
 		}
 	}
-
 }

--- a/src/main/java/com/httpserver/config/Configuration.java
+++ b/src/main/java/com/httpserver/config/Configuration.java
@@ -1,30 +1,65 @@
 package com.httpserver.config;
 
+/**
+ * Represents the configuration settings for the HTTP server.
+ * This class holds the server's port number and the web root directory.
+ */
 public class Configuration {
 
     private int port;
     private String webroot;
 
+    /**
+     * Default constructor for creating a Configuration object
+     * with default values.
+     */
     public Configuration() {
     }
 
+    /**
+     * Constructs a Configuration object with the specified port
+     * number and web root directory.
+     *
+     * @param port     the port number for the HTTP server
+     * @param webroot  the web root directory for serving files
+     */
     public Configuration(int port, String webroot) {
         this.port = port;
         this.webroot = webroot;
     }
 
+    /**
+     * Returns the port number for the HTTP server.
+     *
+     * @return the port number
+     */
     public int getPort() {
         return port;
     }
 
+    /**
+     * Sets the port number for the HTTP server.
+     *
+     * @param port the port number to set
+     */
     public void setPort(int port) {
         this.port = port;
     }
 
+    /**
+     * Returns the web root directory for serving files.
+     *
+     * @return the web root directory
+     */
     public String getWebroot() {
         return webroot;
     }
 
+    /**
+     * Sets the web root directory for serving files.
+     *
+     * @param webroot the web root directory to set
+     */
     public void setWebroot(String webroot) {
         this.webroot = webroot;
     }

--- a/src/main/java/com/httpserver/config/ConfigurationManager.java
+++ b/src/main/java/com/httpserver/config/ConfigurationManager.java
@@ -7,15 +7,28 @@ import java.io.FileNotFoundException;
 import java.io.FileReader;
 import java.io.IOException;
 
+/**
+ * Manages the configuration settings for the HTTP server.
+ * This class follows the Singleton design pattern to ensure that
+ * only one instance of the configuration manager exists throughout
+ * the application.
+ */
 public class ConfigurationManager {
 
     private static ConfigurationManager configurationManager;
     private static Configuration myCurrentConfiguration;
 
+    /**
+     * Private constructor to prevent instantiation from outside the class.
+     */
     private ConfigurationManager() {
-
     }
 
+    /**
+     * Retrieves the single instance of the ConfigurationManager.
+     *
+     * @return the singleton instance of ConfigurationManager
+     */
     public static ConfigurationManager getInstance() {
         if (configurationManager == null) {
             configurationManager = new ConfigurationManager();
@@ -23,22 +36,32 @@ public class ConfigurationManager {
         return configurationManager;
     }
 
-
-//    User to load a configuration file by the path provided
-    public void loadConfigurationFile(String filePath)  {
+    /**
+     * Loads a configuration file from the specified file path.
+     * <p>
+     * This method reads the contents of the configuration file, parses
+     * it into a JSON structure, and populates the current configuration
+     * object. If the file is not found or there are issues parsing the
+     * configuration, it throws an {@link HttpConfigurationException}.
+     * </p>
+     *
+     * @param filePath the path to the configuration file to be loaded
+     * @throws HttpConfigurationException if the configuration file is not found
+     *                                     or if an error occurs while parsing
+     */
+    public void loadConfigurationFile(String filePath) {
         FileReader fileReader = null;
-        try{
+        try {
             fileReader = new FileReader(filePath);
-        }catch (FileNotFoundException e){
+        } catch (FileNotFoundException e) {
             throw new HttpConfigurationException(e);
         }
         StringBuffer sb = new StringBuffer();
-//        BufferedReader bufferedReader = new BufferedReader(fileReader);
 
         int i;
         try {
-            while( (i = fileReader.read()) != -1 ){
-                sb.append((char)i);
+            while ((i = fileReader.read()) != -1) {
+                sb.append((char) i);
             }
         } catch (IOException e) {
             throw new HttpConfigurationException(e);
@@ -48,21 +71,24 @@ public class ConfigurationManager {
         try {
             config = Json.parse(sb.toString());
         } catch (IOException e) {
-            throw new HttpConfigurationException("Error parsing the Configuration file",e);
+            throw new HttpConfigurationException("Error parsing the Configuration file", e);
         }
 
         try {
-            myCurrentConfiguration = Json.fromJson(config,Configuration.class);
+            myCurrentConfiguration = Json.fromJson(config, Configuration.class);
         } catch (IOException e) {
-            throw new HttpConfigurationException("Error parsing the Configuration file INTERNAL",e);
+            throw new HttpConfigurationException("Error parsing the Configuration file INTERNAL", e);
         }
-
     }
 
-
-    // Returns the current loaded Configuration
+    /**
+     * Returns the current loaded configuration.
+     *
+     * @return the current Configuration object
+     * @throws HttpConfigurationException if no current configuration is set
+     */
     public Configuration getCurrentConfiguration() {
-        if ( myCurrentConfiguration == null ) {
+        if (myCurrentConfiguration == null) {
             throw new HttpConfigurationException("No Current Configuration Set.");
         }
         return myCurrentConfiguration;

--- a/src/main/java/com/httpserver/config/HttpConfigurationException.java
+++ b/src/main/java/com/httpserver/config/HttpConfigurationException.java
@@ -1,22 +1,55 @@
 package com.httpserver.config;
 
+/**
+ * Custom exception class to handle configuration-related errors in the HTTP server.
+ * This class extends {@link RuntimeException} to provide specific error handling
+ * for configuration issues.
+ */
 public class HttpConfigurationException extends RuntimeException {
 
+    /**
+     * Constructs a new HttpConfigurationException with {@code null} as its detail message.
+     */
     public HttpConfigurationException() {
     }
 
+    /**
+     * Constructs a new HttpConfigurationException with the specified detail message.
+     *
+     * @param message the detail message, which is saved for later retrieval by the {@link #getMessage()} method
+     */
     public HttpConfigurationException(String message) {
         super(message);
     }
 
+    /**
+     * Constructs a new HttpConfigurationException with the specified detail message and cause.
+     *
+     * @param message the detail message, which is saved for later retrieval by the {@link #getMessage()} method
+     * @param cause   the cause (which is saved for later retrieval by the {@link #getCause()} method)
+     */
     public HttpConfigurationException(String message, Throwable cause) {
         super(message, cause);
     }
 
+    /**
+     * Constructs a new HttpConfigurationException with the specified cause.
+     *
+     * @param cause the cause (which is saved for later retrieval by the {@link #getCause()} method)
+     */
     public HttpConfigurationException(Throwable cause) {
         super(cause);
     }
 
+    /**
+     * Constructs a new HttpConfigurationException with the specified detail message, cause, suppression enabled or disabled,
+     * and writable stack trace enabled or disabled.
+     *
+     * @param message            the detail message, which is saved for later retrieval by the {@link #getMessage()} method
+     * @param cause              the cause (which is saved for later retrieval by the {@link #getCause()} method)
+     * @param enableSuppression  whether or not suppression is enabled or disabled
+     * @param writableStackTrace whether or not the stack trace should be writable
+     */
     public HttpConfigurationException(String message, Throwable cause, boolean enableSuppression, boolean writableStackTrace) {
         super(message, cause, enableSuppression, writableStackTrace);
     }

--- a/src/main/java/com/httpserver/core/HttpConnectionWorkerThread.java
+++ b/src/main/java/com/httpserver/core/HttpConnectionWorkerThread.java
@@ -8,29 +8,51 @@ import java.io.InputStream;
 import java.io.OutputStream;
 import java.net.Socket;
 
+/**
+ * Represents a worker thread for handling HTTP connections.
+ * This class extends Thread to manage the communication
+ * between the server and a client over a given socket.
+ */
 public class HttpConnectionWorkerThread extends Thread {
     private final static Logger LOGGER = LoggerFactory.getLogger(HttpConnectionWorkerThread.class);
 
     private final Socket socket;
+
+    /**
+     * Constructs an HttpConnectionWorkerThread with the specified socket.
+     *
+     * @param socket the socket connected to the client
+     */
     public HttpConnectionWorkerThread(Socket socket) {
         this.socket = socket;
     }
 
+    /**
+     * Runs the worker thread, handling incoming requests and sending responses.
+     * <p>
+     * This method reads data from the input stream of the socket,
+     * processes the HTTP request, and writes a simple HTML response
+     * back to the client. It logs the completion of the connection
+     * and handles any IOExceptions that may occur during communication.
+     * </p>
+     *
+     * @throws IOException if an I/O error occurs while reading from or writing to the socket
+     */
     @Override
     public void run() {
         try(InputStream inputStream = socket.getInputStream();
             OutputStream outputStream = socket.getOutputStream();
-            ) {
+        ) {
 
-//            int _byte;
-//            while ( (_byte = inputStream.read() ) >= 0) {
-//                System.out.print( (char) _byte );
-//            //    outputStream.write(_byte);
-//            }
+            // int _byte;
+            // while ( (_byte = inputStream.read() ) >= 0) {
+            //     System.out.print( (char) _byte );
+            //     //    outputStream.write(_byte);
+            // }
 
-            String html = "<html><head><title>Simple Java HTTP Server</title></head><body>This is page was served using java</body></html>";
+            String html = "<html><head><title>Simple Java HTTP Server</title></head><body>This page was served using Java</body></html>";
 
-//          CRLF = Carriage Return (\r) and Line Feed (\n)
+            // CRLF = Carriage Return (\r) and Line Feed (\n)
             final String CRLF = "\r\n"; // 10 , 13 ASIC CODE
 
             String response =
@@ -41,25 +63,19 @@ public class HttpConnectionWorkerThread extends Thread {
             outputStream.write(response.getBytes());
             // TODO we would read
 
-
             // TODO we would writing
 
-
-
-            LOGGER.info("Conection completed..");
+            LOGGER.info("Connection completed..");
         } catch (IOException e) {
             LOGGER.error("Problem with Communication", e);
             e.printStackTrace();
         }
-//        finally {
-//            inputStream.close();
-//            outputStream.close();
-//            socket.close();
-//
-//
-////            serverSocket.close(); // TODO Handle close
-
-//        }
-
+        // finally {
+        //     inputStream.close();
+        //     outputStream.close();
+        //     socket.close();
+        //
+        //     // serverSocket.close(); // TODO Handle close
+        // }
     }
 }

--- a/src/main/java/com/httpserver/core/ServerListenerThread.java
+++ b/src/main/java/com/httpserver/core/ServerListenerThread.java
@@ -9,6 +9,11 @@ import java.net.Socket;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+/**
+ * Represents a server listener thread that accepts incoming HTTP connections.
+ * This class extends Thread to manage the lifecycle of the server socket
+ * and handle client requests by spawning worker threads.
+ */
 public class ServerListenerThread extends Thread {
     private final static Logger LOGGER = LoggerFactory.getLogger(ServerListenerThread.class);
 
@@ -16,38 +21,52 @@ public class ServerListenerThread extends Thread {
     private String webroot;
     private final ServerSocket serverSocket;
 
+    /**
+     * Constructs a ServerListenerThread with the specified port and web root.
+     *
+     * @param port the port on which the server will listen for incoming connections
+     * @param webroot the root directory for serving web content
+     * @throws IOException if an I/O error occurs when opening the server socket
+     */
     public ServerListenerThread(int port, String webroot) throws IOException {
         this.port = port;
         this.webroot = webroot;
         this.serverSocket = new ServerSocket(this.port);
     }
+
+    /**
+     * Runs the server listener thread, accepting incoming connections and
+     * spawning worker threads to handle them.
+     * <p>
+     * This method loops until the server socket is closed, accepting
+     * connections and creating an instance of {@link HttpConnectionWorkerThread}
+     * for each accepted socket connection. It logs connection information
+     * and handles any IOExceptions that may occur during socket operations.
+     * </p>
+     *
+     * @throws IOException if an I/O error occurs while waiting for a connection
+     */
     @Override
     public void run() {
-
         try {
             while (serverSocket.isBound() && !serverSocket.isClosed()) {
-
-
-                Socket socket = serverSocket.accept(); // Code wait here until the connection is accepted.
-
+                Socket socket = serverSocket.accept(); // Code waits here until the connection is accepted.
 
                 LOGGER.info("* Connection accepted on port {}", this.port);
                 LOGGER.info("* Connection accepted: " + serverSocket.getInetAddress());
 
                 HttpConnectionWorkerThread workerThread = new HttpConnectionWorkerThread(socket);
                 workerThread.start();
-
             }
         } catch (IOException e) {
             LOGGER.error("Problem with setting socket", e);
             e.printStackTrace();
-        }finally {
+        } finally {
             try {
                 serverSocket.close();
             } catch (IOException e) {
-                LOGGER.error("Error in closing ServerSocket in  serverListenerThread", e);
+                LOGGER.error("Error in closing ServerSocket in ServerListenerThread", e);
             }
         }
-
     }
 }

--- a/src/main/java/com/httpserver/http/HttpMethod.java
+++ b/src/main/java/com/httpserver/http/HttpMethod.java
@@ -1,8 +1,37 @@
 package com.httpserver.http;
 
+/**
+ * Enum representing standard HTTP methods used in requests.
+ */
 public enum HttpMethod {
-    GET, HEAD;
+    /** The GET method requests data from a specified resource. */
+    GET,
 
+    /** The HEAD method requests the headers of a specified resource without the body. */
+    HEAD,
+
+    /** The POST method submits data to be processed to a specified resource. */
+    POST,
+
+    /** The PUT method updates a current resource with new data. */
+    PUT,
+
+    /** The DELETE method deletes a specified resource. */
+    DELETE,
+
+    /** The CONNECT method establishes a tunnel to a server identified by a given URI. */
+    CONNECT,
+
+    /** The OPTIONS method describes the communication options for the target resource. */
+    OPTIONS,
+
+    /** The TRACE method performs a message loop-back test along the path to the target resource. */
+    TRACE,
+
+    /** The PATCH method applies partial modifications to a resource. */
+    PATCH;
+
+    /** The maximum length of the HTTP method names. */
     public static final int MAX_LENGTH;
 
     static {

--- a/src/main/java/com/httpserver/http/HttpParser.java
+++ b/src/main/java/com/httpserver/http/HttpParser.java
@@ -3,20 +3,30 @@ package com.httpserver.http;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.io.BufferedReader;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.nio.charset.StandardCharsets;
 
-
+/**
+ * Parses HTTP requests from an InputStream.
+ */
 public class HttpParser {
 
     private final static Logger LOGGER = LoggerFactory.getLogger(HttpParser.class);
 
-    private static final int SP = 0x20; // 32
-    private static final int CR = 0x0D; // 13
-    private static final int LF = 0x0A; // 10
+    private static final int SP = 0x20; // Space character
+    private static final int CR = 0x0D; // Carriage return
+    private static final int LF = 0x0A; // Line feed
 
+    /**
+     * Parses an HTTP request from the provided InputStream.
+     *
+     * @param inputStream the InputStream containing the HTTP request data
+     * @return the parsed HttpRequest object
+     * @throws HttpParsingException if there is an error during parsing
+     */
     public HttpRequest parseHttpRequest(InputStream inputStream) throws HttpParsingException {
         InputStreamReader reader = new InputStreamReader(inputStream, StandardCharsets.US_ASCII);
 
@@ -24,75 +34,147 @@ public class HttpParser {
 
         try {
             parseRequestLine(reader, httpRequest);
+            parseHeaders(reader, httpRequest);
+            parseBody(reader, httpRequest);
         } catch (IOException e) {
-            e.printStackTrace();
+            LOGGER.error("I/O error during parsing: {}", e.getMessage());
+            throw new HttpParsingException(HttpStatusCode.SERVER_ERROR_500_INTERNAL_SERVER_ERROR);
         }
-        parseHeaders(reader, httpRequest);
-        parseBody(reader, httpRequest);
 
         return httpRequest;
     }
 
+    /**
+     * Parses the request line of the HTTP request.
+     *
+     * @param reader  the InputStreamReader to read the request line
+     * @param request the HttpRequest object to populate
+     * @throws IOException           if an I/O error occurs
+     * @throws HttpParsingException  if the request line is invalid
+     */
     private void parseRequestLine(InputStreamReader reader, HttpRequest request) throws IOException, HttpParsingException {
         StringBuilder processingDataBuffer = new StringBuilder();
-
         boolean methodParsed = false;
         boolean requestTargetParsed = false;
 
-        // TODO validate URI size!
-
         int _byte;
-        while ((_byte = reader.read()) >=0) {
+        while ((_byte = reader.read()) >= 0) {
             if (_byte == CR) {
                 _byte = reader.read();
                 if (_byte == LF) {
-                    LOGGER.debug("Request Line VERSION to Process : {}" , processingDataBuffer.toString());
                     if (!methodParsed || !requestTargetParsed) {
+                        LOGGER.warn("Method or Request Target not parsed properly.");
                         throw new HttpParsingException(HttpStatusCode.CLIENT_ERROR_400_BAD_REQUEST);
                     }
-
-                    try {
-                        request.setHttpVersion(processingDataBuffer.toString());
-                    } catch (BadHttpVersionException e) {
-                        throw new HttpParsingException(HttpStatusCode.CLIENT_ERROR_400_BAD_REQUEST);
-                    }
-
                     return;
                 } else {
+                    LOGGER.error("CRLF expected but got: {}", _byte);
                     throw new HttpParsingException(HttpStatusCode.CLIENT_ERROR_400_BAD_REQUEST);
                 }
             }
 
             if (_byte == SP) {
                 if (!methodParsed) {
-                    LOGGER.debug("Request Line METHOD to Process : {}" , processingDataBuffer.toString());
-                    request.setMethod(processingDataBuffer.toString());
+                    LOGGER.debug("Request Line METHOD to Process: {}", processingDataBuffer.toString());
+                    try {
+                        request.setMethod(HttpMethod.valueOf(processingDataBuffer.toString()));
+                        LOGGER.debug("Parsed HTTP Method: {}", request.getMethod());
+                    } catch (IllegalArgumentException e) {
+                        LOGGER.error("Unsupported HTTP Method: {}", processingDataBuffer.toString());
+                        throw new HttpParsingException(HttpStatusCode.SERVER_ERROR_501_NOT_IMPLEMENTED);
+                    }
                     methodParsed = true;
                 } else if (!requestTargetParsed) {
-                    LOGGER.debug("Request Line REQ TARGET to Process : {}" , processingDataBuffer.toString());
+                    if (processingDataBuffer.length() == 0) {
+                        LOGGER.warn("Empty Request Target found.");
+                        throw new HttpParsingException(HttpStatusCode.CLIENT_ERROR_400_BAD_REQUEST);
+                    }
+                    LOGGER.debug("Request Line REQ TARGET to Process: {}", processingDataBuffer.toString());
                     request.setRequestTarget(processingDataBuffer.toString());
                     requestTargetParsed = true;
                 } else {
+                    LOGGER.error("Extra space detected in request line.");
                     throw new HttpParsingException(HttpStatusCode.CLIENT_ERROR_400_BAD_REQUEST);
                 }
-                processingDataBuffer.delete(0, processingDataBuffer.length());
+                processingDataBuffer.setLength(0); // Clear buffer
             } else {
-                processingDataBuffer.append((char)_byte);
-                if (!methodParsed) {
-                    if (processingDataBuffer.length() > HttpMethod.MAX_LENGTH) {
-                        throw new HttpParsingException(HttpStatusCode.SERVER_ERROR_501_NOT_IMPLEMENTED);
-                    }
+                processingDataBuffer.append((char) _byte);
+                if (!methodParsed && processingDataBuffer.length() > HttpMethod.MAX_LENGTH) {
+                    LOGGER.error("HTTP Method length exceeded max limit.");
+                    throw new HttpParsingException(HttpStatusCode.SERVER_ERROR_501_NOT_IMPLEMENTED);
                 }
             }
         }
     }
 
+    /**
+     * Parses the headers of the HTTP request.
+     *
+     * @param reader      the InputStreamReader to read the headers
+     * @param httpRequest the HttpRequest object to populate with headers
+     * @throws IOException           if an I/O error occurs
+     * @throws HttpParsingException  if a header is invalid
+     */
+    private void parseHeaders(InputStreamReader reader, HttpRequest httpRequest) throws IOException, HttpParsingException {
+        BufferedReader bufferedReader = new BufferedReader(reader);
+        String line;
 
-    private void parseHeaders(InputStreamReader reader, HttpRequest httpRequest) {
+        while ((line = bufferedReader.readLine()) != null && !line.isEmpty()) {
+            String[] header = line.split(": ", 2);
+            if (header.length != 2) {
+                LOGGER.error("Invalid header format: {}", line);
+                throw new HttpParsingException(HttpStatusCode.CLIENT_ERROR_400_BAD_REQUEST);
+            }
+
+            String headerName = header[0];
+            String headerValue = header[1];
+            httpRequest.addHeader(headerName, headerValue);
+            LOGGER.debug("Parsed Header: {}: {}", headerName, headerValue);
+        }
     }
 
-    private void parseBody(InputStreamReader reader, HttpRequest httpRequest) {
+    /**
+     * Parses the body of the HTTP request based on the Content-Length header.
+     *
+     * @param reader      the InputStreamReader to read the body
+     * @param httpRequest the HttpRequest object to populate with the body
+     * @throws IOException           if an I/O error occurs
+     * @throws HttpParsingException  if the body cannot be parsed correctly
+     */
+    private void parseBody(InputStreamReader reader, HttpRequest httpRequest) throws IOException, HttpParsingException {
+        String contentLengthHeader = httpRequest.getHeaders().get("Content-Length");
+
+        if (contentLengthHeader == null || contentLengthHeader.isEmpty()) {
+            httpRequest.setBody("");
+            return;
+        }
+
+        int contentLength;
+        try {
+            contentLength = Integer.parseInt(contentLengthHeader);
+        } catch (NumberFormatException e) {
+            throw new HttpParsingException(HttpStatusCode.CLIENT_ERROR_400_BAD_REQUEST);
+        }
+
+        if (contentLength <= 0) {
+            httpRequest.setBody("");
+            return;
+        }
+
+        char[] buffer = new char[1024];
+        StringBuilder bodyBuilder = new StringBuilder(contentLength);
+        int totalBytesRead = 0;
+        int bytesRead;
+
+        while (totalBytesRead < contentLength && (bytesRead = reader.read(buffer, 0, Math.min(buffer.length, contentLength - totalBytesRead))) != -1) {
+            bodyBuilder.append(buffer, 0, bytesRead);
+            totalBytesRead += bytesRead;
+        }
+
+        if (totalBytesRead < contentLength) {
+            throw new HttpParsingException(HttpStatusCode.CLIENT_ERROR_400_BAD_REQUEST);
+        }
+
+        httpRequest.setBody(bodyBuilder.toString());
     }
-
-
 }

--- a/src/main/java/com/httpserver/http/HttpParsingException.java
+++ b/src/main/java/com/httpserver/http/HttpParsingException.java
@@ -2,14 +2,24 @@ package com.httpserver.http;
 
 public class HttpParsingException extends Exception {
 
-    private final HttpStatusCode errorCode;
+    private final HttpStatusCode statusCode;
 
-    public HttpParsingException(HttpStatusCode errorCode) {
-        super(errorCode.MESSAGE);
-        this.errorCode = errorCode;
+    /**
+     * Constructs a new HttpParsingException with the specified HttpStatusCode.
+     *
+     * @param statusCode the HTTP status code associated with the exception
+     */
+    public HttpParsingException(HttpStatusCode statusCode) {
+        super(statusCode.MESSAGE);
+        this.statusCode = statusCode;
     }
 
-    public HttpStatusCode getErrorCode() {
-        return errorCode;
+    /**
+     * Returns the HTTP status code associated with this exception.
+     *
+     * @return the HttpStatusCode
+     */
+    public HttpStatusCode getStatusCode() {
+        return statusCode;
     }
 }

--- a/src/main/java/com/httpserver/http/HttpRequest.java
+++ b/src/main/java/com/httpserver/http/HttpRequest.java
@@ -1,57 +1,155 @@
 package com.httpserver.http;
 
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * Represents an HTTP request message, including the method, target, HTTP version,
+ * headers, and body.
+ */
 public class HttpRequest extends HttpMessage {
 
     private HttpMethod method;
     private String requestTarget;
     private String originalHttpVersion; // literal from the request
     private HttpVersion bestCompatibleHttpVersion;
+    private final Map<String, String> headers = new HashMap<>(); // To store headers
+    private String body; // To store the body of the request
 
+    /**
+     * Default constructor for HttpRequest.
+     */
     HttpRequest() {
     }
 
+    /**
+     * Gets the HTTP method of the request.
+     *
+     * @return the HTTP method.
+     */
     public HttpMethod getMethod() {
         return method;
     }
 
+    /**
+     * Gets the request target.
+     *
+     * @return the request target.
+     */
     public String getRequestTarget() {
         return requestTarget;
     }
 
+    /**
+     * Gets the best compatible HTTP version determined for the request.
+     *
+     * @return the best compatible HTTP version.
+     */
     public HttpVersion getBestCompatibleHttpVersion() {
         return bestCompatibleHttpVersion;
     }
 
+    /**
+     * Gets the original HTTP version from the request.
+     *
+     * @return the original HTTP version.
+     */
     public String getOriginalHttpVersion() {
         return originalHttpVersion;
     }
 
-    void setMethod(String methodName) throws HttpParsingException {
-        for (HttpMethod method: HttpMethod.values()) {
-            if (methodName.equals(method.name())) {
-                this.method = method;
-                return;
-            }
-        }
-        throw new HttpParsingException(
-                HttpStatusCode.SERVER_ERROR_501_NOT_IMPLEMENTED
-        );
+    /**
+     * Gets all headers included in the request.
+     *
+     * @return a map of headers, where the key is the header name and the value is the header value.
+     */
+    public Map<String, String> getHeaders() {
+        return headers;
     }
 
+    /**
+     * Gets the body of the request.
+     *
+     * @return the body of the request as a string.
+     */
+    public String getBody() {
+        return body;
+    }
+
+    /**
+     * Sets the HTTP method for the request.
+     *
+     * @param method the HTTP method to set.
+     */
+    void setMethod(HttpMethod method) {
+        this.method = method;
+    }
+
+    /**
+     * Sets the request target.
+     *
+     * @param requestTarget the target to set.
+     * @throws HttpParsingException if the request target is null or empty.
+     */
     void setRequestTarget(String requestTarget) throws HttpParsingException {
-        if (requestTarget == null || requestTarget.length() == 0) {
+        if (requestTarget == null || requestTarget.isEmpty()) {
             throw new HttpParsingException(HttpStatusCode.SERVER_ERROR_500_INTERNAL_SERVER_ERROR);
         }
         this.requestTarget = requestTarget;
     }
 
+    /**
+     * Sets the original HTTP version for the request and determines the best compatible version.
+     *
+     * @param originalHttpVersion the original HTTP version to set.
+     * @throws BadHttpVersionException if the provided HTTP version is invalid.
+     * @throws HttpParsingException if the HTTP version is not supported.
+     */
     void setHttpVersion(String originalHttpVersion) throws BadHttpVersionException, HttpParsingException {
         this.originalHttpVersion = originalHttpVersion;
         this.bestCompatibleHttpVersion = HttpVersion.getBestCompatibleVersion(originalHttpVersion);
         if (this.bestCompatibleHttpVersion == null) {
-            throw new HttpParsingException(
-                    HttpStatusCode.SERVER_ERROR_505_HTTP_VERSION_NOT_SUPPORTED
-            );
+            throw new HttpParsingException(HttpStatusCode.SERVER_ERROR_505_HTTP_VERSION_NOT_SUPPORTED);
         }
+    }
+
+    /**
+     * Adds a header to the request.
+     *
+     * @param name the name of the header.
+     * @param value the value of the header.
+     * @throws IllegalArgumentException if the header name or value is null or empty.
+     */
+    public void addHeader(String name, String value) {
+        if (name == null || name.isEmpty() || value == null) {
+            throw new IllegalArgumentException("Header name and value must not be null or empty");
+        }
+        headers.put(name, value);
+    }
+
+    /**
+     * Sets the body of the HTTP request.
+     *
+     * @param body the body to set.
+     */
+    public void setBody(String body) {
+        this.body = body;
+    }
+
+    /**
+     * Returns a string representation of the HttpRequest.
+     *
+     * @return a string containing the details of the HTTP request.
+     */
+    @Override
+    public String toString() {
+        return "HttpRequest{" +
+                "method=" + method +
+                ", requestTarget='" + requestTarget + '\'' +
+                ", originalHttpVersion='" + originalHttpVersion + '\'' +
+                ", bestCompatibleHttpVersion=" + bestCompatibleHttpVersion +
+                ", headers=" + headers +
+                ", body='" + body + '\'' +
+                '}';
     }
 }

--- a/src/main/java/com/httpserver/http/HttpStatusCode.java
+++ b/src/main/java/com/httpserver/http/HttpStatusCode.java
@@ -1,25 +1,48 @@
 package com.httpserver.http;
 
+/**
+ * Enum representing standard HTTP status codes and their associated messages.
+ */
 public enum HttpStatusCode {
+
+    /* --- SUCCESS CODES --- */
+    SUCCESS_200_OK(200, "OK"),
+    SUCCESS_201_CREATED(201, "Created"),
+    SUCCESS_204_NO_CONTENT(204, "No Content"),
 
     /* --- CLIENT ERRORS --- */
     CLIENT_ERROR_400_BAD_REQUEST(400, "Bad Request"),
-    CLIENT_ERROR_401_METHOD_NOT_ALLOWED(401, "Method Not Allowed"),
-    CLIENT_ERROR_414_BAD_REQUEST(414, "URI Too Long"),
+    CLIENT_ERROR_401_UNAUTHORIZED(401, "Unauthorized"),
+    CLIENT_ERROR_403_FORBIDDEN(403, "Forbidden"),
+    CLIENT_ERROR_404_NOT_FOUND(404, "Not Found"),
+    CLIENT_ERROR_405_METHOD_NOT_ALLOWED(405, "Method Not Allowed"),
+    CLIENT_ERROR_408_REQUEST_TIMEOUT(408, "Request Timeout"),
+    CLIENT_ERROR_413_PAYLOAD_TOO_LARGE(413, "Payload Too Large"),
+    CLIENT_ERROR_415_UNSUPPORTED_MEDIA_TYPE(415, "Unsupported Media Type"),
+    CLIENT_ERROR_429_TOO_MANY_REQUESTS(429, "Too Many Requests"),
 
     /* --- SERVER ERRORS --- */
     SERVER_ERROR_500_INTERNAL_SERVER_ERROR(500, "Internal Server Error"),
     SERVER_ERROR_501_NOT_IMPLEMENTED(501, "Not Implemented"),
-    SERVER_ERROR_505_HTTP_VERSION_NOT_SUPPORTED(505, "Http Version Not Supported")
-    ;
+    SERVER_ERROR_502_BAD_GATEWAY(502, "Bad Gateway"),
+    SERVER_ERROR_503_SERVICE_UNAVAILABLE(503, "Service Unavailable"),
+    SERVER_ERROR_504_GATEWAY_TIMEOUT(504, "Gateway Timeout"),
+    SERVER_ERROR_505_HTTP_VERSION_NOT_SUPPORTED(505, "HTTP Version Not Supported");
 
-
+    /** The numeric status code. */
     public final int STATUS_CODE;
+
+    /** The message associated with the status code. */
     public final String MESSAGE;
 
+    /**
+     * Constructor to create an instance of HttpStatusCode with a status code and message.
+     *
+     * @param STATUS_CODE the numeric status code.
+     * @param MESSAGE the message associated with the status code.
+     */
     HttpStatusCode(int STATUS_CODE, String MESSAGE) {
         this.STATUS_CODE = STATUS_CODE;
         this.MESSAGE = MESSAGE;
     }
-
 }

--- a/src/main/java/com/httpserver/http/HttpVersion.java
+++ b/src/main/java/com/httpserver/http/HttpVersion.java
@@ -1,22 +1,47 @@
 package com.httpserver.http;
+
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
+/**
+ * Enum representing HTTP versions and their associated properties.
+ */
 public enum HttpVersion {
-    HTTP_1_1("HTTP/1.1", 1 , 1);
+    /** HTTP version 1.1 */
+    HTTP_1_1("HTTP/1.1", 1, 1);
 
+    /** The literal representation of the HTTP version. */
     public final String LITERAL;
+
+    /** The major version number. */
     public final int MAJOR;
+
+    /** The minor version number. */
     public final int MINOR;
 
+    /**
+     * Constructor to create an instance of HttpVersion with a literal, major, and minor version.
+     *
+     * @param LITERAL the literal representation of the HTTP version.
+     * @param MAJOR the major version number.
+     * @param MINOR the minor version number.
+     */
     HttpVersion(String LITERAL, int MAJOR, int MINOR) {
         this.LITERAL = LITERAL;
         this.MAJOR = MAJOR;
         this.MINOR = MINOR;
     }
 
+    /** Regular expression pattern to match HTTP version literals. */
     private static final Pattern httpVersionRegexPattern = Pattern.compile("^HTTP/(?<major>\\d+).(?<minor>\\d+)");
 
+    /**
+     * Retrieves the best compatible HttpVersion based on the provided literal version.
+     *
+     * @param literalVersion the literal representation of the HTTP version to check.
+     * @return the best compatible HttpVersion if found.
+     * @throws BadHttpVersionException if the provided version is invalid or unsupported.
+     */
     public static HttpVersion getBestCompatibleVersion(String literalVersion) throws BadHttpVersionException {
         Matcher matcher = httpVersionRegexPattern.matcher(literalVersion);
         if (!matcher.find() || matcher.groupCount() != 2) {

--- a/src/main/java/com/httpserver/utils/Json.java
+++ b/src/main/java/com/httpserver/utils/Json.java
@@ -5,43 +5,97 @@ import com.fasterxml.jackson.databind.*;
 
 import java.io.IOException;
 
+/**
+ * Utility class for handling JSON operations using Jackson's ObjectMapper.
+ * This class provides methods for parsing, converting, and generating JSON.
+ */
 public class Json {
 
     private static ObjectMapper mapper = defaultObjectMapper();
 
-    private static ObjectMapper defaultObjectMapper(){
+    /**
+     * Creates a default ObjectMapper with specific configuration.
+     *
+     * @return a configured ObjectMapper instance
+     */
+    private static ObjectMapper defaultObjectMapper() {
         ObjectMapper mapper = new ObjectMapper();
-        mapper.configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES,false);
+        mapper.configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
         return mapper;
     }
 
+    /**
+     * Parses the given JSON string into a JsonNode.
+     *
+     * @param jsonSrc the JSON string to be parsed
+     * @return a JsonNode representing the parsed JSON
+     * @throws JsonProcessingException if there is a problem processing the JSON
+     * @throws IOException if an I/O error occurs while reading the JSON
+     */
     public static JsonNode parse(String jsonSrc) throws JsonProcessingException, IOException {
         return mapper.readTree(jsonSrc);
     }
 
+    /**
+     * Converts a JsonNode to an object of the specified class.
+     *
+     * @param node  the JsonNode to convert
+     * @param clazz the class of the object to convert to
+     * @param <A>   the type of the object to return
+     * @return an object of type A represented by the JsonNode
+     * @throws JsonProcessingException if there is a problem processing the JSON
+     * @throws IOException if an I/O error occurs during conversion
+     */
     public static <A> A fromJson(JsonNode node, Class<A> clazz) throws JsonProcessingException, IOException {
         return mapper.convertValue(node, clazz);
     }
 
+    /**
+     * Converts an object to a JsonNode.
+     *
+     * @param obj the object to convert
+     * @return a JsonNode representing the object
+     */
     public static JsonNode toJson(Object obj) {
         return mapper.valueToTree(obj);
     }
 
+    /**
+     * Converts a JsonNode to a JSON string.
+     *
+     * @param node the JsonNode to convert
+     * @return a JSON string representation of the JsonNode
+     * @throws JsonProcessingException if there is a problem processing the JSON
+     */
     private static String stringify(JsonNode node) throws JsonProcessingException {
-        return generateJson(node,false);
+        return generateJson(node, false);
     }
 
+    /**
+     * Converts a JsonNode to a pretty-printed JSON string.
+     *
+     * @param node the JsonNode to convert
+     * @return a pretty-printed JSON string representation of the JsonNode
+     * @throws JsonProcessingException if there is a problem processing the JSON
+     */
     private static String stringifyPretty(JsonNode node) throws JsonProcessingException {
-        return generateJson(node,true);
+        return generateJson(node, true);
     }
 
+    /**
+     * Generates a JSON string from an object.
+     *
+     * @param obj    the object to convert to JSON
+     * @param pretty whether to pretty-print the JSON output
+     * @return a JSON string representation of the object
+     * @throws JsonProcessingException if there is a problem processing the JSON
+     */
     private static String generateJson(Object obj, boolean pretty) throws JsonProcessingException {
         ObjectWriter writer = mapper.writer();
 
-        if (pretty){
+        if (pretty) {
             writer = writer.with(SerializationFeature.INDENT_OUTPUT);
         }
         return writer.writeValueAsString(obj);
     }
-
 }

--- a/src/test/java/com/httpserver/http/HttpMethodTest.java
+++ b/src/test/java/com/httpserver/http/HttpMethodTest.java
@@ -1,0 +1,43 @@
+package com.httpserver.http;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class HttpMethodTest {
+
+    @Test
+    void testEnumValues() {
+        HttpMethod[] expectedMethods = {
+                HttpMethod.GET, HttpMethod.HEAD, HttpMethod.POST,
+                HttpMethod.PUT, HttpMethod.DELETE, HttpMethod.CONNECT,
+                HttpMethod.OPTIONS, HttpMethod.TRACE, HttpMethod.PATCH
+        };
+        assertArrayEquals(expectedMethods, HttpMethod.values());
+    }
+
+    @Test
+    void testMaxLength() {
+        assertEquals(7, HttpMethod.MAX_LENGTH);
+    }
+
+    @Test
+    void testMethodNameLengths() {
+        for (HttpMethod method : HttpMethod.values()) {
+            assertTrue(method.name().length() <= HttpMethod.MAX_LENGTH);
+        }
+    }
+
+    @Test
+    void testEnumOrdinal() {
+        assertEquals(0, HttpMethod.GET.ordinal());
+        assertEquals(1, HttpMethod.HEAD.ordinal());
+        assertEquals(2, HttpMethod.POST.ordinal());
+        assertEquals(3, HttpMethod.PUT.ordinal());
+        assertEquals(4, HttpMethod.DELETE.ordinal());
+        assertEquals(5, HttpMethod.CONNECT.ordinal());
+        assertEquals(6, HttpMethod.OPTIONS.ordinal());
+        assertEquals(7, HttpMethod.TRACE.ordinal());
+        assertEquals(8, HttpMethod.PATCH.ordinal());
+    }
+}

--- a/src/test/java/com/httpserver/http/HttpParserTest.java
+++ b/src/test/java/com/httpserver/http/HttpParserTest.java
@@ -1,0 +1,94 @@
+package com.httpserver.http;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.io.ByteArrayInputStream;
+import java.io.InputStream;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class HttpParserTest {
+
+    private HttpParser httpParser;
+
+    @BeforeEach
+    void setUp() {
+        httpParser = new HttpParser();
+    }
+
+    @Test
+    void testParseHttpRequest_ValidRequest() throws HttpParsingException {
+        String requestString = "GET /index.html HTTP/1.1\r\n" +
+                "Host: example.com\r\n" +
+                "Content-Length: 0\r\n\r\n";
+        InputStream inputStream = new ByteArrayInputStream(requestString.getBytes());
+
+        HttpRequest httpRequest = httpParser.parseHttpRequest(inputStream);
+
+        assertNotNull(httpRequest);
+        assertEquals(HttpMethod.GET, httpRequest.getMethod());
+        assertEquals("/index.html", httpRequest.getRequestTarget());
+        assertEquals("example.com", httpRequest.getHeaders().get("Host"));
+        assertEquals(0, httpRequest.getBody().length());
+    }
+
+    @Test
+    void testParseHttpRequest_InvalidMethod() {
+        String requestString = "INVALID_METHOD /index.html HTTP/1.1\r\n\r\n";
+        InputStream inputStream = new ByteArrayInputStream(requestString.getBytes());
+
+        HttpParsingException exception = assertThrows(HttpParsingException.class, () -> {
+            httpParser.parseHttpRequest(inputStream);
+        });
+
+        assertEquals(HttpStatusCode.SERVER_ERROR_501_NOT_IMPLEMENTED, exception.getStatusCode());
+    }
+
+    @Test
+    void testParseHttpRequest_MissingRequestTarget() {
+        String requestString = "GET  HTTP/1.1\r\n\r\n";
+        InputStream inputStream = new ByteArrayInputStream(requestString.getBytes());
+
+        HttpParsingException exception = assertThrows(HttpParsingException.class, () -> {
+            httpParser.parseHttpRequest(inputStream);
+        });
+
+        assertEquals(HttpStatusCode.CLIENT_ERROR_400_BAD_REQUEST, exception.getStatusCode());
+    }
+
+    @Test
+    void testParseHttpRequest_InvalidHeader() {
+        String requestString = "GET /index.html HTTP/1.1\r\n" +
+                "InvalidHeader\r\n\r\n";
+        InputStream inputStream = new ByteArrayInputStream(requestString.getBytes());
+
+        HttpParsingException exception = assertThrows(HttpParsingException.class, () -> {
+            httpParser.parseHttpRequest(inputStream);
+        });
+
+        assertEquals(HttpStatusCode.CLIENT_ERROR_400_BAD_REQUEST, exception.getStatusCode());
+    }
+
+
+    @Test
+    void testParseHttpRequest_BodyWithZeroContentLength() throws HttpParsingException {
+        String requestString = "POST /submit HTTP/1.1\r\n" +
+                "Content-Length: 0\r\n\r\n";
+        InputStream inputStream = new ByteArrayInputStream(requestString.getBytes());
+
+        HttpRequest httpRequest = httpParser.parseHttpRequest(inputStream);
+
+        assertEquals("", httpRequest.getBody());
+    }
+
+    @Test
+    void testParseHttpRequest_MissingContentLength() throws HttpParsingException {
+        String requestString = "POST /submit HTTP/1.1\r\n\r\n";
+        InputStream inputStream = new ByteArrayInputStream(requestString.getBytes());
+
+        HttpRequest httpRequest = httpParser.parseHttpRequest(inputStream);
+
+        assertEquals("", httpRequest.getBody());
+    }
+}

--- a/src/test/java/com/httpserver/http/HttpParsingExceptionTest.java
+++ b/src/test/java/com/httpserver/http/HttpParsingExceptionTest.java
@@ -1,0 +1,21 @@
+package com.httpserver.http;
+
+import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.*;
+
+class HttpParsingExceptionTest {
+
+    @Test
+    void testHttpParsingExceptionMessage() {
+        HttpStatusCode statusCode = HttpStatusCode.CLIENT_ERROR_400_BAD_REQUEST;
+        HttpParsingException exception = new HttpParsingException(statusCode);
+        assertEquals(statusCode.MESSAGE, exception.getMessage());
+    }
+
+    @Test
+    void testHttpParsingExceptionStatusCode() {
+        HttpStatusCode statusCode = HttpStatusCode.CLIENT_ERROR_404_NOT_FOUND;
+        HttpParsingException exception = new HttpParsingException(statusCode);
+        assertEquals(statusCode, exception.getStatusCode());
+    }
+}

--- a/src/test/java/com/httpserver/http/HttpRequestTest.java
+++ b/src/test/java/com/httpserver/http/HttpRequestTest.java
@@ -1,0 +1,100 @@
+package com.httpserver.http;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class HttpRequestTest {
+
+    private HttpRequest httpRequest;
+
+    @BeforeEach
+    void setUp() {
+        httpRequest = new HttpRequest();
+    }
+
+    @Test
+    void testSetMethod_GET() {
+        HttpMethod method = HttpMethod.GET;
+        httpRequest.setMethod(method);
+        assertEquals(method, httpRequest.getMethod());
+    }
+
+    @Test
+    void testSetMethod_POST() {
+        HttpMethod method = HttpMethod.POST;
+        httpRequest.setMethod(method);
+        assertEquals(method, httpRequest.getMethod());
+    }
+
+    @Test
+    void testSetMethod_PUT() {
+        HttpMethod method = HttpMethod.PUT;
+        httpRequest.setMethod(method);
+        assertEquals(method, httpRequest.getMethod());
+    }
+
+    @Test
+    void testSetMethod_DELETE() {
+        HttpMethod method = HttpMethod.DELETE;
+        httpRequest.setMethod(method);
+        assertEquals(method, httpRequest.getMethod());
+    }
+
+    @Test
+    void testSetRequestTarget_Valid() throws HttpParsingException {
+        String validTarget = "/api/resource";
+        httpRequest.setRequestTarget(validTarget);
+        assertEquals(validTarget, httpRequest.getRequestTarget());
+    }
+
+    @Test
+    void testSetRequestTarget_EmptyTarget() {
+        assertThrows(HttpParsingException.class, () -> {
+            httpRequest.setRequestTarget("");
+        });
+    }
+
+    @Test
+    void testSetRequestTarget_NullTarget() {
+        assertThrows(HttpParsingException.class, () -> {
+            httpRequest.setRequestTarget(null);
+        });
+    }
+
+    @Test
+    void testSetHttpVersion_Valid() throws BadHttpVersionException, HttpParsingException {
+        String validHttpVersion = "HTTP/1.1";
+        httpRequest.setHttpVersion(validHttpVersion);
+        assertEquals(validHttpVersion, httpRequest.getOriginalHttpVersion());
+        assertEquals(HttpVersion.HTTP_1_1, httpRequest.getBestCompatibleHttpVersion());
+    }
+
+    @Test
+    void testSetHttpVersion_Invalid() {
+        assertThrows(BadHttpVersionException.class, () -> {
+            httpRequest.setHttpVersion("INVALID_VERSION");
+        });
+    }
+
+    @Test
+    void testSetHttpVersion_Unsupported() {
+        assertThrows(HttpParsingException.class, () -> {
+            httpRequest.setHttpVersion("HTTP/2.0");
+        });
+    }
+
+    @Test
+    void testAddHeader() {
+        httpRequest.addHeader("Content-Type", "application/json");
+        assertEquals("application/json", httpRequest.getHeaders().get("Content-Type"));
+    }
+
+    @Test
+    void testSetBody() {
+        String bodyContent = "This is a request body";
+        httpRequest.setBody(bodyContent);
+        assertEquals(bodyContent, httpRequest.getBody());
+    }
+}

--- a/src/test/java/com/httpserver/http/HttpStatusCodeTest.java
+++ b/src/test/java/com/httpserver/http/HttpStatusCodeTest.java
@@ -1,0 +1,67 @@
+package com.httpserver.http;
+
+import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+public class HttpStatusCodeTest {
+
+    @Test
+    public void testHttpStatusCodeValues() {
+        // Test SUCCESS CODES
+        assertEquals(200, HttpStatusCode.SUCCESS_200_OK.STATUS_CODE);
+        assertEquals("OK", HttpStatusCode.SUCCESS_200_OK.MESSAGE);
+
+        assertEquals(201, HttpStatusCode.SUCCESS_201_CREATED.STATUS_CODE);
+        assertEquals("Created", HttpStatusCode.SUCCESS_201_CREATED.MESSAGE);
+
+        assertEquals(204, HttpStatusCode.SUCCESS_204_NO_CONTENT.STATUS_CODE);
+        assertEquals("No Content", HttpStatusCode.SUCCESS_204_NO_CONTENT.MESSAGE);
+
+        // Test CLIENT ERRORS
+        assertEquals(400, HttpStatusCode.CLIENT_ERROR_400_BAD_REQUEST.STATUS_CODE);
+        assertEquals("Bad Request", HttpStatusCode.CLIENT_ERROR_400_BAD_REQUEST.MESSAGE);
+
+        assertEquals(401, HttpStatusCode.CLIENT_ERROR_401_UNAUTHORIZED.STATUS_CODE);
+        assertEquals("Unauthorized", HttpStatusCode.CLIENT_ERROR_401_UNAUTHORIZED.MESSAGE);
+
+        assertEquals(403, HttpStatusCode.CLIENT_ERROR_403_FORBIDDEN.STATUS_CODE);
+        assertEquals("Forbidden", HttpStatusCode.CLIENT_ERROR_403_FORBIDDEN.MESSAGE);
+
+        assertEquals(404, HttpStatusCode.CLIENT_ERROR_404_NOT_FOUND.STATUS_CODE);
+        assertEquals("Not Found", HttpStatusCode.CLIENT_ERROR_404_NOT_FOUND.MESSAGE);
+
+        assertEquals(405, HttpStatusCode.CLIENT_ERROR_405_METHOD_NOT_ALLOWED.STATUS_CODE);
+        assertEquals("Method Not Allowed", HttpStatusCode.CLIENT_ERROR_405_METHOD_NOT_ALLOWED.MESSAGE);
+
+        assertEquals(408, HttpStatusCode.CLIENT_ERROR_408_REQUEST_TIMEOUT.STATUS_CODE);
+        assertEquals("Request Timeout", HttpStatusCode.CLIENT_ERROR_408_REQUEST_TIMEOUT.MESSAGE);
+
+        assertEquals(413, HttpStatusCode.CLIENT_ERROR_413_PAYLOAD_TOO_LARGE.STATUS_CODE);
+        assertEquals("Payload Too Large", HttpStatusCode.CLIENT_ERROR_413_PAYLOAD_TOO_LARGE.MESSAGE);
+
+        assertEquals(415, HttpStatusCode.CLIENT_ERROR_415_UNSUPPORTED_MEDIA_TYPE.STATUS_CODE);
+        assertEquals("Unsupported Media Type", HttpStatusCode.CLIENT_ERROR_415_UNSUPPORTED_MEDIA_TYPE.MESSAGE);
+
+        assertEquals(429, HttpStatusCode.CLIENT_ERROR_429_TOO_MANY_REQUESTS.STATUS_CODE);
+        assertEquals("Too Many Requests", HttpStatusCode.CLIENT_ERROR_429_TOO_MANY_REQUESTS.MESSAGE);
+
+        // Test SERVER ERRORS
+        assertEquals(500, HttpStatusCode.SERVER_ERROR_500_INTERNAL_SERVER_ERROR.STATUS_CODE);
+        assertEquals("Internal Server Error", HttpStatusCode.SERVER_ERROR_500_INTERNAL_SERVER_ERROR.MESSAGE);
+
+        assertEquals(501, HttpStatusCode.SERVER_ERROR_501_NOT_IMPLEMENTED.STATUS_CODE);
+        assertEquals("Not Implemented", HttpStatusCode.SERVER_ERROR_501_NOT_IMPLEMENTED.MESSAGE);
+
+        assertEquals(502, HttpStatusCode.SERVER_ERROR_502_BAD_GATEWAY.STATUS_CODE);
+        assertEquals("Bad Gateway", HttpStatusCode.SERVER_ERROR_502_BAD_GATEWAY.MESSAGE);
+
+        assertEquals(503, HttpStatusCode.SERVER_ERROR_503_SERVICE_UNAVAILABLE.STATUS_CODE);
+        assertEquals("Service Unavailable", HttpStatusCode.SERVER_ERROR_503_SERVICE_UNAVAILABLE.MESSAGE);
+
+        assertEquals(504, HttpStatusCode.SERVER_ERROR_504_GATEWAY_TIMEOUT.STATUS_CODE);
+        assertEquals("Gateway Timeout", HttpStatusCode.SERVER_ERROR_504_GATEWAY_TIMEOUT.MESSAGE);
+
+        assertEquals(505, HttpStatusCode.SERVER_ERROR_505_HTTP_VERSION_NOT_SUPPORTED.STATUS_CODE);
+        assertEquals("HTTP Version Not Supported", HttpStatusCode.SERVER_ERROR_505_HTTP_VERSION_NOT_SUPPORTED.MESSAGE);
+    }
+}

--- a/src/test/java/com/httpserver/http/HttpVersionTest.java
+++ b/src/test/java/com/httpserver/http/HttpVersionTest.java
@@ -1,0 +1,40 @@
+package com.httpserver.http;
+
+import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.*;
+
+class HttpVersionTest {
+
+    @Test
+    void testValidHttpVersion() throws BadHttpVersionException {
+        HttpVersion version = HttpVersion.getBestCompatibleVersion("HTTP/1.1");
+        assertNotNull(version);
+        assertEquals(HttpVersion.HTTP_1_1, version);
+    }
+
+    @Test
+    void testInvalidHttpVersionFormat() {
+        assertThrows(BadHttpVersionException.class, () -> {
+            HttpVersion.getBestCompatibleVersion("HTTP/2");
+        });
+    }
+
+    @Test
+    void testUnsupportedHttpVersion() throws BadHttpVersionException {
+        HttpVersion version = HttpVersion.getBestCompatibleVersion("HTTP/1.0");
+        assertNull(version);
+    }
+
+    @Test
+    void testMatchingMajorVersion() throws BadHttpVersionException {
+        HttpVersion version = HttpVersion.getBestCompatibleVersion("HTTP/1.0");
+        assertNull(version); // Expect null since 1.0 is not in the enum
+    }
+
+    @Test
+    void testInvalidVersionPattern() {
+        assertThrows(BadHttpVersionException.class, () -> {
+            HttpVersion.getBestCompatibleVersion("INVALID/1.1");
+        });
+    }
+}


### PR DESCRIPTION
### Description

This commit includes several enhancements:

- **Added** support for additional HTTP methods (POST, PUT, DELETE, CONNECT, OPTIONS, TRACE, PATCH) in the API, enabling more flexible interactions.
- **Created Unit Tests** for testing the HTTP methods and the new implementations.
- **Improved** Javadoc comments for better clarity and understanding of the code.
- **Enhanced** documentation to facilitate better onboarding for contributors, ensuring they can easily navigate and contribute to the project.

### Related Issues
This pull request closes issues: 
- #1
- #2
- #3

All test are passing attaching the SnapShot below:

![Screenshot from 2024-10-04 05-25-08](https://github.com/user-attachments/assets/98925470-6839-40d1-ad55-c4dcbe967d70)


Pls let me know if I can improve anywhere or do something more 😊