### PR TITLE
Add Security Headers for enhanced security

### DIFF
--- a/src/main/java/com/httpserver/http/HttpResponse.java
+++ b/src/main/java/com/httpserver/http/HttpResponse.java
@@ -1,0 +1,117 @@
+package com.httpserver.http;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+/**
+ * Represents an HTTP response, containing status code, headers, and body.
+ */
+public class HttpResponse {
+
+    private HttpStatusCode statusCode;
+    private HttpVersion httpVersion;
+    private String body;
+    private Map<String, String> headers;
+
+    /**
+     * Constructs an empty HttpResponse with default settings.
+     * Initializes headers using a LinkedHashMap to preserve insertion order.
+     */
+    public HttpResponse() {
+        headers = new LinkedHashMap<>();
+    }
+
+    /**
+     * Retrieves the HTTP status code of the response.
+     *
+     * @return The status code of the response.
+     */
+    public HttpStatusCode getStatusCode() {
+        return statusCode;
+    }
+
+    /**
+     * Retrieves the HTTP version of the response.
+     *
+     * @return The HTTP version of the response.
+     */
+    public HttpVersion getHttpVersion() {
+        return httpVersion;
+    }
+
+    /**
+     * Retrieves the body content of the response.
+     *
+     * @return The body content as a string.
+     */
+    public String getBody() {
+        return body;
+    }
+
+    /**
+     * Sets the HTTP status code for the response.
+     *
+     * @param statusCode The status code to be set.
+     */
+    public void setStatusCode(HttpStatusCode statusCode) {
+        this.statusCode = statusCode;
+    }
+
+    /**
+     * Sets the HTTP version for the response.
+     *
+     * @param httpVersion The HTTP version to be set.
+     */
+    public void setHttpVersion(HttpVersion httpVersion) {
+        this.httpVersion = httpVersion;
+    }
+
+    /**
+     * Sets the body content of the response.
+     *
+     * @param body The body content to be set.
+     */
+    public void setBody(String body) {
+        this.body = body;
+    }
+
+    /**
+     * Adds a header to the HTTP response.
+     *
+     * @param key The header name.
+     * @param value The header value.
+     */
+    public void addHeader(String key, String value) {
+        headers.put(key, value);
+    }
+
+    /**
+     * Builds the HTTP response by constructing the status line, headers, and body.
+     * 
+     * @return The complete HTTP response as a formatted string.
+     */
+    public String buildResponse() {
+        String CRLF = "\r\n";
+        StringBuilder response = new StringBuilder();
+
+        // Status line
+        response.append(httpVersion.LITERAL).append(" ")
+                .append(statusCode.STATUS_CODE).append(" ")
+                .append(statusCode.MESSAGE).append(CRLF);
+
+        // Headers
+        for (Map.Entry<String, String> header : headers.entrySet()) {
+            response.append(header.getKey()).append(": ").append(header.getValue()).append(CRLF);
+        }
+
+        // Empty line to indicate the end of headers
+        response.append(CRLF);
+
+        // Body (if present)
+        if (body != null && !body.isEmpty()) {
+            response.append(body).append(CRLF);
+        }
+
+        return response.toString();
+    }
+}

--- a/src/main/java/com/httpserver/http/HttpStatusCode.java
+++ b/src/main/java/com/httpserver/http/HttpStatusCode.java
@@ -27,7 +27,10 @@ public enum HttpStatusCode {
     SERVER_ERROR_502_BAD_GATEWAY(502, "Bad Gateway"),
     SERVER_ERROR_503_SERVICE_UNAVAILABLE(503, "Service Unavailable"),
     SERVER_ERROR_504_GATEWAY_TIMEOUT(504, "Gateway Timeout"),
-    SERVER_ERROR_505_HTTP_VERSION_NOT_SUPPORTED(505, "HTTP Version Not Supported");
+    SERVER_ERROR_505_HTTP_VERSION_NOT_SUPPORTED(505, "HTTP Version Not Supported"),
+	
+	/* --- REDIRECTION CODES --- */
+	REDIRECTION_301_MOVED_PERMANENTLY(301, "Moved Permanently");
 
     /** The numeric status code. */
     public final int STATUS_CODE;

--- a/src/main/java/com/httpserver/middleware/Middleware.java
+++ b/src/main/java/com/httpserver/middleware/Middleware.java
@@ -1,0 +1,16 @@
+package com.httpserver.middleware;
+
+import com.httpserver.http.HttpResponse;
+
+/**
+ * Interface for middleware components.
+ * Middleware components can modify or inspect HTTP responses.
+ */
+public interface Middleware {
+    /**
+     * Applies the middleware logic to modify the HTTP response.
+     *
+     * @param response The HttpResponse object that will be modified by this middleware.
+     */
+    void apply(HttpResponse response);
+}

--- a/src/main/java/com/httpserver/middleware/SecurityHeadersMiddleware.java
+++ b/src/main/java/com/httpserver/middleware/SecurityHeadersMiddleware.java
@@ -1,0 +1,24 @@
+package com.httpserver.middleware;
+
+import com.httpserver.http.HttpResponse;
+
+/**
+ * Middleware that applies standard security headers to HTTP responses.
+ */
+public class SecurityHeadersMiddleware implements Middleware {
+
+    /**
+     * Applies security headers to the HTTP response, including:
+     * - Content-Security-Policy: Restricts the sources for scripts and styles.
+     * - Strict-Transport-Security: Enforces HTTPS usage.
+     * - X-Content-Type-Options: Prevents MIME type sniffing.
+     *
+     * @param response The HttpResponse to which security headers are added.
+     */
+    @Override
+    public void apply(HttpResponse response) {
+        response.addHeader("Content-Security-Policy", "default-src 'self'; script-src 'self'; style-src 'self'");
+        response.addHeader("Strict-Transport-Security", "max-age=31536000; includeSubDomains");
+        response.addHeader("X-Content-Type-Options", "nosniff");
+    }
+}


### PR DESCRIPTION
This pull request adds the `SecurityHeadersMiddleware` to implement essential security headers and modifies the HTTP worker threads to include these headers in responses.

### Changes Made
- **Added** `SecurityHeadersMiddleware` that implements the following security headers:
  - **Content-Security-Policy**: Restricts the loading of scripts and resources.
  - **Strict-Transport-Security**: Enforces the use of HTTPS.
  - **X-Content-Type-Options**: Prevents MIME type sniffing.

- **Added** the `HttpResponse` class for building the HTTP response.
- **Updated** `HttpConnectionWorkerThread` and `HttpsConnectionWorkerThread` to apply the security headers middleware in their responses.

### Output
1. **HTTP Server**

    ```bash
    curl -i http://localhost:8080
    ```

    **Response:**

    ```
    HTTP/1.1 301 Moved Permanently
    Location: https://172.30.96.1:8043/
    Content-Security-Policy: default-src 'self'; script-src 'self'; style-src 'self'
    Strict-Transport-Security: max-age=31536000; includeSubDomains
    X-Content-Type-Options: nosniff
    Connection: close
    ```

2. **HTTPS Server**

    ```bash
    curl -ik https://localhost:8043
    ```

    **Response:**

    ```
    HTTP/1.1 200 OK
    Content-Type: text/html
    Content-Length: 109
    Content-Security-Policy: default-src 'self'; script-src 'self'; style-src 'self'
    Strict-Transport-Security: max-age=31536000; includeSubDomains
    X-Content-Type-Options: nosniff

    <html><head><title>Simple Java HTTPS Server</title></head><body>This page was served using Java</body></html>
    ```

Related Issues #7