### PR TITLE
Adjust createSSLServerSocket access, add getters for server listeners, and validate port values

### DIFF
--- a/src/main/java/com/httpserver/config/HttpServerConfiguration.java
+++ b/src/main/java/com/httpserver/config/HttpServerConfiguration.java
@@ -4,115 +4,124 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 /**
- * Represents the configuration settings for the HTTP and HTTPS server.
- * This class holds the server's port numbers for HTTP and HTTPS, and 
- * the web root directory for serving files.
+ * Represents the configuration settings for the HTTP and HTTPS server. This
+ * class holds the server's port numbers for HTTP and HTTPS, and the web root
+ * directory for serving files.
  */
 public class HttpServerConfiguration {
 
-	private static final Logger logger = LoggerFactory.getLogger(HttpServerConfiguration.class); // SLF4J logger instance
-	
-    private int httpPort;
-    private int httpsPort;
-    private String webroot;
+	private static final Logger logger = LoggerFactory.getLogger(HttpServerConfiguration.class); // SLF4J logger
+																									// instance
 
-    /**
-     * Default constructor for creating a Configuration object
-     * with default values.
-     */
-    public HttpServerConfiguration() { 
-    	logger.info("Created a new HttpServerConfiguration object with default values.");
-    	logger.trace("Default HttpServerConfiguration constructor invoked.");
-    }
+	private int httpPort;
+	private int httpsPort;
+	private String webroot;
 
-    /**
-     * Constructs a Configuration object with the specified HTTP and HTTPS
-     * port numbers, and the web root directory.
-     *
-     * @param httpPort   the port number for the HTTP server
-     * @param httpsPort  the port number for the HTTPS server
-     * @param webroot    the web root directory for serving files
-     */
-    public HttpServerConfiguration(int httpPort, int httpsPort, String webroot) {
-        this.httpPort = httpPort;
-        this.httpsPort = httpsPort;
-        this.webroot = webroot;
-        logger.info("Created a new HttpServerConfiguration object with http port: {}, https port {} and webroot: {}", httpPort, httpsPort, webroot);
-        logger.trace("HttpServerConfiguration object initialized with http port: {}, https port {} and webroot {}", httpPort, httpsPort, webroot);
-    }
+	/**
+	 * Default constructor for creating a Configuration object with default values.
+	 */
+	public HttpServerConfiguration() {
+		logger.info("Created a new HttpServerConfiguration object with default values.");
+		logger.trace("Default HttpServerConfiguration constructor invoked.");
+	}
 
-    /**
-     * Returns the port number for the HTTP server.
-     *
-     * @return the HTTP port number
-     */
-    public int getHttpPort() {
-    	logger.debug("Retrieved http port: {}", httpPort);
-        logger.trace("getHttpPort() called, returning: {}", httpPort);
-        return httpPort;
-    }
+	/**
+	 * Constructs a Configuration object with the specified HTTP and HTTPS port
+	 * numbers, and the web root directory.
+	 *
+	 * @param httpPort  the port number for the HTTP server
+	 * @param httpsPort the port number for the HTTPS server
+	 * @param webroot   the web root directory for serving files
+	 */
+	public HttpServerConfiguration(int httpPort, int httpsPort, String webroot) {
+		this.httpPort = httpPort;
+		this.httpsPort = httpsPort;
+		this.webroot = webroot;
+		logger.info("Created a new HttpServerConfiguration object with http port: {}, https port {} and webroot: {}",
+				httpPort, httpsPort, webroot);
+		logger.trace("HttpServerConfiguration object initialized with http port: {}, https port {} and webroot {}",
+				httpPort, httpsPort, webroot);
+	}
 
-    /**
-     * Sets the port number for the HTTP server.
-     *
-     * @param httpPort the HTTP port number to set
-     */
-    public void setHttpPort(int httpPort) { 
-    	logger.info("Setting http port to: {}", httpPort);    
-        this.httpPort = httpPort;
-        logger.trace("Http port set to: {}", httpPort);
-    }
+	/**
+	 * Returns the port number for the HTTP server.
+	 *
+	 * @return the HTTP port number
+	 */
+	public int getHttpPort() {
+		logger.debug("Retrieved http port: {}", httpPort);
+		logger.trace("getHttpPort() called, returning: {}", httpPort);
+		return httpPort;
+	}
 
-    /**
-     * Returns the port number for the HTTPS server.
-     *
-     * @return the HTTPS port number
-     */
-    public int getHttpsPort() {
-    	logger.debug("Retrieved https port: {}", httpsPort);
-        logger.trace("getHttpsPort() called, returning: {}", httpsPort);
-        return httpsPort;
-    }
+	/**
+	 * Sets the port number for the HTTP server.
+	 *
+	 * @param httpPort the HTTP port number to set
+	 * @throws IllegalArgumentException if the provided port number is negative
+	 */
+	public void setHttpPort(int httpPort) {
+		if (httpPort < 0) {
+			logger.error("Attempted to set a negative HTTP port: {}", httpPort);
+			throw new IllegalArgumentException("HTTP port number cannot be negative: " + httpPort);
+		}
+		logger.info("Setting http port to: {}", httpPort);
+		this.httpPort = httpPort;
+		logger.trace("Http port set to: {}", httpPort);
+	}
 
-    /**
-     * Sets the port number for the HTTPS server.
-     *
-     * @param httpsPort the HTTPS port number to set
-     */
-    public void setHttpsPort(int httpsPort) {
-    	logger.info("Setting https port to: {}", httpsPort);    
-        this.httpsPort = httpsPort;
-        logger.trace("Https port set to: {}", httpsPort);
-    }
+	/**
+	 * Returns the port number for the HTTPS server.
+	 *
+	 * @return the HTTPS port number
+	 */
+	public int getHttpsPort() {
+		logger.debug("Retrieved https port: {}", httpsPort);
+		logger.trace("getHttpsPort() called, returning: {}", httpsPort);
+		return httpsPort;
+	}
 
-    /**
-     * Returns the web root directory for serving files.
-     *
-     * @return the web root directory
-     */
-    public String getWebroot() {
-    	logger.debug("Retrieved webroot: {}", webroot);
-        logger.trace("getWebroot() called, returning: {}", webroot);
-        return webroot;
-    }
+	/**
+	 * Sets the port number for the HTTPS server.
+	 *
+	 * @param httpsPort the HTTPS port number to set
+	 * @throws IllegalArgumentException if the provided port number is negative
+	 */
+	public void setHttpsPort(int httpsPort) {
+		if (httpsPort < 0) {
+	        logger.error("Attempted to set a negative HTTPS port: {}", httpsPort);
+	        throw new IllegalArgumentException("HTTPS port number cannot be negative: " + httpsPort);
+	    }
+		logger.info("Setting https port to: {}", httpsPort);
+		this.httpsPort = httpsPort;
+		logger.trace("Https port set to: {}", httpsPort);
+	}
 
-    /**
-     * Sets the web root directory for serving files.
-     *
-     * @param webroot the web root directory to set
-     */
-    public void setWebroot(String webroot) {
-    	logger.info("Setting webroot to: {}", webroot);
-        this.webroot = webroot;
-        logger.trace("Webroot set to: {}", webroot);
-    }
-    
-    @Override
-    public String toString() {
-        return "HttpServerConfiguration{" +
-                "httpPort=" + httpPort +
-                ", httpsPort="+ httpsPort +
-                ", webroot='" + webroot + '\'' +
-                '}';
-    }
+	/**
+	 * Returns the web root directory for serving files.
+	 *
+	 * @return the web root directory
+	 */
+	public String getWebroot() {
+		logger.debug("Retrieved webroot: {}", webroot);
+		logger.trace("getWebroot() called, returning: {}", webroot);
+		return webroot;
+	}
+
+	/**
+	 * Sets the web root directory for serving files.
+	 *
+	 * @param webroot the web root directory to set
+	 */
+	public void setWebroot(String webroot) {
+		logger.info("Setting webroot to: {}", webroot);
+		this.webroot = webroot;
+		logger.trace("Webroot set to: {}", webroot);
+	}
+
+	@Override
+	public String toString() {
+		return "HttpServerConfiguration{" + "httpPort=" + httpPort + ", httpsPort=" + httpsPort + ", webroot='"
+				+ webroot + '\'' + '}';
+	}
 }

--- a/src/main/java/com/httpserver/core/http/HttpServerListenerThread.java
+++ b/src/main/java/com/httpserver/core/http/HttpServerListenerThread.java
@@ -33,6 +33,24 @@ public class HttpServerListenerThread extends Thread {
 		this.serverSocket = new ServerSocket(this.port);
 		LOGGER.debug("HTTP - Server initialized on port: {} with webroot: {}", this.port, this.webroot);
 	}
+	
+	/**
+	 * Returns the port number of HTTP Server.
+	 *
+	 * @return the port number
+	 */
+    public int getPort() {
+        return port;
+    }
+
+    /**
+	 * Returns the web root directory for serving files.
+	 *
+	 * @return the web root directory
+	 */
+    public String getWebroot() {
+        return webroot;
+    }
 
 	/**
 	 * Runs the server listener thread, accepting incoming connections and spawning

--- a/src/main/java/com/httpserver/core/https/HttpsServerListenerThread.java
+++ b/src/main/java/com/httpserver/core/https/HttpsServerListenerThread.java
@@ -44,6 +44,24 @@ public class HttpsServerListenerThread extends Thread {
 		this.serverSocket = createSSLServerSocket();
 		LOGGER.debug("HTTPS - Server initialized on port: {} with webroot: {}", this.port, this.webroot);
 	}
+	
+	/**
+	 * Returns the port number of HTTPS Server.
+	 *
+	 * @return the port number
+	 */
+    public int getPort() {
+        return port;
+    }
+
+    /**
+	 * Returns the web root directory for serving files.
+	 *
+	 * @return the web root directory
+	 */
+    public String getWebroot() {
+        return webroot;
+    }
 
 	/**
 	 * Creates and initializes the SSLServerSocket based on the SSL configuration.
@@ -52,7 +70,7 @@ public class HttpsServerListenerThread extends Thread {
 	 * @throws Exception if an error occurs while loading the keystore or
 	 *                   initializing the socket
 	 */
-	private SSLServerSocket createSSLServerSocket() throws Exception {
+	 SSLServerSocket createSSLServerSocket() throws Exception {
 	    LOGGER.info("Initializing SSL server socket...");
 
 		SSLConfiguration sslConfig = ConfigurationManager.getInstance().getConfiguration(SSLConfiguration.class);


### PR DESCRIPTION
This PR implements changes based on the requirements for adding unit tests related to PR #19:
- Changed `createSSLServerSocket()` to have default access to enhance testability.
- Introduced getter methods for the server listener threads, facilitating testing without compromising the class's internal state.
- Implemented validation in `setHttpPort()` and `setHttpsPort()` methods to ensure that negative values are not accepted.

These changes aim to improve the overall test coverage and ensure robust functionality. 